### PR TITLE
Use stdout for datapoint exports

### DIFF
--- a/manager/src/main/java/org/openremote/manager/datapoint/AssetDatapointService.java
+++ b/manager/src/main/java/org/openremote/manager/datapoint/AssetDatapointService.java
@@ -5,7 +5,6 @@ import org.openremote.agent.protocol.ProtocolDatapointService;
 import org.openremote.container.timer.TimerService;
 import org.openremote.manager.asset.OutdatedAttributeEvent;
 import org.openremote.model.datapoint.DatapointExportFormat;
-import org.openremote.model.datapoint.DatapointQueryTooLargeException;
 import org.openremote.manager.asset.AssetProcessingException;
 import org.openremote.manager.asset.AssetStorageService;
 import org.openremote.manager.event.ClientEventService;
@@ -29,8 +28,6 @@ import org.postgresql.PGConnection;
 import org.postgresql.copy.CopyManager;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.Date;
 import java.time.*;
 import java.util.Arrays;
@@ -60,14 +57,10 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
 
     public static final String OR_DATA_POINTS_MAX_AGE_DAYS = "OR_DATA_POINTS_MAX_AGE_DAYS";
     public static final int OR_DATA_POINTS_MAX_AGE_DAYS_DEFAULT = 31;
-    public static final String OR_DATA_POINTS_EXPORT_LIMIT = "OR_DATA_POINTS_EXPORT_LIMIT";
-    public static final int OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT = 1000000;
     private static final Logger LOG = Logger.getLogger(AssetDatapointService.class.getName());
     private static final Logger DATA_EXPORT_LOG = SyslogCategory.getLogger(DATA, AssetDatapointResourceImpl.class);
     protected static final String EXPORT_STORAGE_DIR_NAME = "datapoint";
     protected int maxDatapointAgeDays;
-    protected int datapointExportLimit;
-    protected Path exportPath;
 
     @Override
     public void init(Container container) throws Exception {
@@ -88,22 +81,6 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
             LOG.warning(OR_DATA_POINTS_MAX_AGE_DAYS + " value is not a valid value so data points won't be auto purged");
         } else {
             LOG.log(Level.INFO, "Data point purge interval days = " + maxDatapointAgeDays);
-        }
-
-        datapointExportLimit = getInteger(container.getConfig(), OR_DATA_POINTS_EXPORT_LIMIT, OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT);
-
-        if (datapointExportLimit <= 0) {
-            LOG.warning(OR_DATA_POINTS_EXPORT_LIMIT + " value is not a valid value so the export data points won't be limited");
-        } else {
-            LOG.log(Level.INFO, "Data point export limit = " + datapointExportLimit);
-        }
-
-        Path storageDir = persistenceService.getStorageDir();
-        exportPath = storageDir.resolve(EXPORT_STORAGE_DIR_NAME);
-        // Ensure export dir exists and is writable
-        Files.createDirectories(exportPath);
-        if (!exportPath.toFile().setWritable(true, false)) {
-            LOG.log(Level.WARNING, "Failed to set export dir write flag; data export may not work");
         }
     }
 
@@ -209,34 +186,6 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Failed to run data points purge", e);
         }
-
-        // Purge old exports
-        try {
-            long oneDayMillis = 24*60*60*1000;
-            File[] obsoleteExports = exportPath.toFile()
-                .listFiles(file ->
-                    file.isFile()
-                        && file.getName().endsWith("csv")
-                        && file.lastModified() < timerService.getCurrentTimeMillis() - oneDayMillis
-                );
-
-            if (obsoleteExports != null) {
-                Arrays.stream(obsoleteExports)
-                    .forEach(file -> {
-                        boolean success = false;
-                        try {
-                            success = file.delete();
-                        } catch (SecurityException e) {
-                            LOG.log(Level.WARNING, "Cannot access the export file to delete it", e);
-                        }
-                        if (!success) {
-                            LOG.log(Level.WARNING, "Failed to delete obsolete export '" + file.getName() + "'");
-                        }
-                    });
-            }
-        } catch (Exception e) {
-            LOG.log(Level.WARNING, "Failed to purge old exports", e);
-        }
     }
 
     protected String buildWhereClause(List<Pair<String, Attribute<?>>> attributes, boolean negate) {
@@ -271,20 +220,13 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
                                                   long fromTimestamp,
                                                   long toTimestamp,
                                                   DatapointExportFormat format) throws IOException {
-        try {
-            String query = getSelectExportQuery(attributeRefs, fromTimestamp, toTimestamp);
+        String query = getSelectExportQuery(attributeRefs, fromTimestamp, toTimestamp);
 
-            // Verify the query is 'legal' and can be executed
-            if (canQueryDatapoints(query, null, datapointExportLimit)) {
-                return doExportDatapoints(attributeRefs, fromTimestamp, toTimestamp, format);
-            }
-            throw new RuntimeException("Could not export datapoints.");
-
-        } catch (DatapointQueryTooLargeException dqex) {
-            String msg = "Could not export data points. It exceeds the data limit of " + datapointExportLimit + " data points.";
-            getLogger().log(Level.WARNING, msg, dqex);
-            throw dqex;
+        // Verify the query is 'legal' and can be executed
+        if (canQueryDatapoints(query, null, 0)) {
+            return doExportDatapoints(attributeRefs, fromTimestamp, toTimestamp, format);
         }
+        throw new RuntimeException("Could not export datapoints.");
     }
 
     protected PipedInputStream doExportDatapoints(AttributeRef[] attributeRefs,

--- a/manager/src/main/java/org/openremote/manager/datapoint/AssetDatapointService.java
+++ b/manager/src/main/java/org/openremote/manager/datapoint/AssetDatapointService.java
@@ -1,11 +1,11 @@
 package org.openremote.manager.datapoint;
 
+import org.hibernate.Session;
 import org.openremote.agent.protocol.ProtocolDatapointService;
 import org.openremote.container.timer.TimerService;
 import org.openremote.manager.asset.OutdatedAttributeEvent;
 import org.openremote.model.datapoint.DatapointExportFormat;
 import org.openremote.model.datapoint.DatapointQueryTooLargeException;
-import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.manager.asset.AssetProcessingException;
 import org.openremote.manager.asset.AssetStorageService;
 import org.openremote.manager.event.ClientEventService;
@@ -21,11 +21,14 @@ import org.openremote.model.datapoint.AssetDatapoint;
 import org.openremote.model.query.AssetQuery;
 import org.openremote.model.query.filter.AttributePredicate;
 import org.openremote.model.query.filter.NameValuePredicate;
+import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.value.MetaHolder;
 import org.openremote.model.value.MetaItemType;
+import org.postgresql.PGConnection;
+import org.postgresql.copy.CopyManager;
 
-import java.io.File;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Date;
@@ -33,7 +36,6 @@ import java.time.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,6 +46,7 @@ import java.util.HashSet;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static org.openremote.model.syslog.SyslogCategory.DATA;
 import static org.openremote.model.util.MapAccess.getInteger;
 import static org.openremote.model.value.MetaItemType.STORE_DATA_POINTS;
 
@@ -60,6 +63,7 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
     public static final String OR_DATA_POINTS_EXPORT_LIMIT = "OR_DATA_POINTS_EXPORT_LIMIT";
     public static final int OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT = 1000000;
     private static final Logger LOG = Logger.getLogger(AssetDatapointService.class.getName());
+    private static final Logger DATA_EXPORT_LOG = SyslogCategory.getLogger(DATA, AssetDatapointResourceImpl.class);
     protected static final String EXPORT_STORAGE_DIR_NAME = "datapoint";
     protected int maxDatapointAgeDays;
     protected int datapointExportLimit;
@@ -253,9 +257,9 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
      * container so it can be accessed by this process.
      * Backwards compatible overload with default format.
      */
-    public ScheduledFuture<File> exportDatapoints(AttributeRef[] attributeRefs,
+    public PipedInputStream exportDatapoints(AttributeRef[] attributeRefs,
                                                   long fromTimestamp,
-                                                  long toTimestamp) {
+                                                  long toTimestamp) throws IOException {
         return exportDatapoints(attributeRefs, fromTimestamp, toTimestamp, DatapointExportFormat.CSV);
     }
 
@@ -263,15 +267,15 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
      * Exports datapoints as CSV using SQL; the export path used in the SQL query must also be mapped into the manager
      * container so it can be accessed by this process.
      */
-    public ScheduledFuture<File> exportDatapoints(AttributeRef[] attributeRefs,
+    public PipedInputStream exportDatapoints(AttributeRef[] attributeRefs,
                                                   long fromTimestamp,
                                                   long toTimestamp,
-                                                  DatapointExportFormat format) {
+                                                  DatapointExportFormat format) throws IOException {
         try {
             String query = getSelectExportQuery(attributeRefs, fromTimestamp, toTimestamp);
 
             // Verify the query is 'legal' and can be executed
-            if(canQueryDatapoints(query, null, datapointExportLimit)) {
+            if (canQueryDatapoints(query, null, datapointExportLimit)) {
                 return doExportDatapoints(attributeRefs, fromTimestamp, toTimestamp, format);
             }
             throw new RuntimeException("Could not export datapoints.");
@@ -283,76 +287,90 @@ public class AssetDatapointService extends AbstractDatapointService<AssetDatapoi
         }
     }
 
-    protected ScheduledFuture<File> doExportDatapoints(AttributeRef[] attributeRefs,
+    protected PipedInputStream doExportDatapoints(AttributeRef[] attributeRefs,
                                                        long fromTimestamp,
                                                        long toTimestamp,
-                                                       DatapointExportFormat format) {
+                                                       DatapointExportFormat format) throws IOException {
+        // Increase buffer size (default is only 1 KB)
+        PipedInputStream in = new PipedInputStream(1024 * 1024 * 4); // 4 MB
+        PipedOutputStream out = new PipedOutputStream(in);
 
-        return scheduledExecutorService.schedule(() -> {
-            String fileName = UniqueIdentifierGenerator.generateId() + ".csv";
-            if (format == DatapointExportFormat.CSV_CROSSTAB) {
-                String attributeFilter = getAttributeFilter(attributeRefs);
-                StringBuilder sb = new StringBuilder(String.format(
-                        "copy (select * from crosstab( " +
-                                "'select ad.timestamp, a.name || '' \\: '' || ad.attribute_name as header, ad.value " +
-                                "from asset_datapoint ad " +
-                                "join asset a on ad.entity_id = a.id " +
-                                "where ad.timestamp >= to_timestamp(%d) and ad.timestamp <= to_timestamp(%d) and (%s) " +
-                                "order by ad.timestamp, header', " +
-                                "'select distinct a.name || '' \\: '' || ad.attribute_name as header " +
-                                "from asset_datapoint ad " +
-                                "join asset a on ad.entity_id = a.id " +
-                                "where %s " +
-                                "order by header') " +
-                                "as ct(timestamp timestamp, %s) " +
-                                ") to '/storage/" + EXPORT_STORAGE_DIR_NAME + "/" + fileName + "' delimiter ',' CSV HEADER;",
-                        fromTimestamp / 1000, toTimestamp / 1000, attributeFilter, attributeFilter, getAttributeColumns(attributeRefs)
-                ));
-                persistenceService.doTransaction(em -> em.createNativeQuery(sb.toString()).executeUpdate());
-            } else if (format == DatapointExportFormat.CSV_CROSSTAB_MINUTE) {
-                String attributeFilter = getAttributeFilter(attributeRefs);
-                StringBuilder sb = new StringBuilder(String.format(
-                        "copy (select * from crosstab( " +
-                                "'select public.time_bucket(''%s'', ad.timestamp) as bucket_timestamp, " +
-                                "a.name || '' \\: '' || ad.attribute_name as header, " +
-                                "CASE " +
-                                "  WHEN jsonb_typeof((array_agg(ad.value))[1]) = ''number'' THEN " +
-                                "    round(avg((ad.value#>>''{}'')::numeric) FILTER (WHERE jsonb_typeof(ad.value) = ''number''), 3)::text " +
-                                "  ELSE (array_agg(ad.value ORDER BY ad.timestamp DESC) FILTER (WHERE jsonb_typeof(ad.value) != ''number''))[1]#>>''{}''" +
-                                "END as value " +
-                                "from asset_datapoint ad " +
-                                "join asset a on ad.entity_id = a.id " +
-                                "where ad.timestamp >= to_timestamp(%d) and ad.timestamp <= to_timestamp(%d) and (%s) " +
-                                "group by bucket_timestamp, header " +
-                                "order by bucket_timestamp, header', " +
-                                "'select distinct a.name || '' \\: '' || ad.attribute_name as header " +
-                                "from asset_datapoint ad " +
-                                "join asset a on ad.entity_id = a.id " +
-                                "where %s " +
-                                "order by header') " +
-                                "as ct(timestamp timestamp, %s) " +
-                                ") to '/storage/" + EXPORT_STORAGE_DIR_NAME + "/" + fileName + "' delimiter ',' CSV HEADER;",
-                        "1 minute", fromTimestamp / 1000, toTimestamp / 1000, attributeFilter, attributeFilter, getAttributeColumns(attributeRefs)
-                ));
+        StringBuilder sb;
 
-                persistenceService.doTransaction(em -> em.createNativeQuery(sb.toString()).executeUpdate());
-            }
-            else {
-                StringBuilder sb = new StringBuilder("copy (")
-                        .append(getSelectExportQuery(attributeRefs, fromTimestamp, toTimestamp))
-                        .append(") to '/storage/")
-                        .append(EXPORT_STORAGE_DIR_NAME)
-                        .append("/")
-                        .append(fileName)
-                        .append("' delimiter ',' CSV HEADER;");
-                persistenceService.doTransaction(em -> em.createNativeQuery(sb.toString()).executeUpdate());
-            }
+        final String TO_STDOUT_WITH_CSV_FORMAT = ") TO STDOUT WITH (FORMAT CSV, HEADER, DELIMITER ',');";
 
+        if (format == DatapointExportFormat.CSV_CROSSTAB) {
+            String attributeFilter = getAttributeFilter(attributeRefs);
+            sb = new StringBuilder(String.format(
+                    "copy (select * from crosstab( " +
+                            "'select ad.timestamp, a.name || '' \\: '' || ad.attribute_name as header, ad.value " +
+                            "from asset_datapoint ad " +
+                            "join asset a on ad.entity_id = a.id " +
+                            "where ad.timestamp >= to_timestamp(%d) and ad.timestamp <= to_timestamp(%d) and (%s) " +
+                            "order by ad.timestamp, header', " +
+                            "'select distinct a.name || '' \\: '' || ad.attribute_name as header " +
+                            "from asset_datapoint ad " +
+                            "join asset a on ad.entity_id = a.id " +
+                            "where %s " +
+                            "order by header') " +
+                            "as ct(timestamp timestamp, %s) " +
+                            TO_STDOUT_WITH_CSV_FORMAT,
+                    fromTimestamp / 1000, toTimestamp / 1000, attributeFilter, attributeFilter, getAttributeColumns(attributeRefs)
+            ));
+        } else if (format == DatapointExportFormat.CSV_CROSSTAB_MINUTE) {
+            String attributeFilter = getAttributeFilter(attributeRefs);
+            sb = new StringBuilder(String.format(
+                    "copy (select * from crosstab( " +
+                            "'select public.time_bucket(''%s'', ad.timestamp) as bucket_timestamp, " +
+                            "a.name || '' \\: '' || ad.attribute_name as header, " +
+                            "CASE " +
+                            "  WHEN jsonb_typeof((array_agg(ad.value))[1]) = ''number'' THEN " +
+                            "    round(avg((ad.value#>>''{}'')::numeric) FILTER (WHERE jsonb_typeof(ad.value) = ''number''), 3)::text " +
+                            "  ELSE (array_agg(ad.value ORDER BY ad.timestamp DESC) FILTER (WHERE jsonb_typeof(ad.value) != ''number''))[1]#>>''{}''" +
+                            "END as value " +
+                            "from asset_datapoint ad " +
+                            "join asset a on ad.entity_id = a.id " +
+                            "where ad.timestamp >= to_timestamp(%d) and ad.timestamp <= to_timestamp(%d) and (%s) " +
+                            "group by bucket_timestamp, header " +
+                            "order by bucket_timestamp, header', " +
+                            "'select distinct a.name || '' \\: '' || ad.attribute_name as header " +
+                            "from asset_datapoint ad " +
+                            "join asset a on ad.entity_id = a.id " +
+                            "where %s " +
+                            "order by header') " +
+                            "as ct(timestamp timestamp, %s) " +
+                            TO_STDOUT_WITH_CSV_FORMAT,
+                    "1 minute", fromTimestamp / 1000, toTimestamp / 1000, attributeFilter, attributeFilter, getAttributeColumns(attributeRefs)
+            ));
+        } else {
+            sb = new StringBuilder("copy (")
+                    .append(getSelectExportQuery(attributeRefs, fromTimestamp, toTimestamp))
+                    .append(TO_STDOUT_WITH_CSV_FORMAT);
+        }
 
+        scheduledExecutorService.schedule(() -> persistenceService.doTransaction(em -> {
+            Session session = em.unwrap(Session.class);
+            session.doWork(connection -> {
+                PGConnection pgConnection = connection.unwrap(PGConnection.class);
+                CopyManager copyManager = pgConnection.getCopyAPI();
+                try {
+                    copyManager.copyOut(sb.toString(), out);
+                    out.flush();
+                    out.close();
+                } catch (IOException e) {
+                    // Either a database connection- or output stream failure
+                    DATA_EXPORT_LOG.log(Level.SEVERE, "Datapoint export failed", e);
+                    try {
+                        out.close();
+                        in.close();
+                    } catch (IOException ignored) {
+                        DATA_EXPORT_LOG.log(Level.SEVERE, "Failed to close piped input stream", e);
+                    }
+                }
+            });
+        }), 0, TimeUnit.MILLISECONDS);
 
-            // The same path must resolve in both the postgresql container and the manager container
-            return exportPath.resolve(fileName).toFile();
-        }, 0, TimeUnit.MILLISECONDS);
+        return in;
     }
 
     /**

--- a/profile/deploy.yml
+++ b/profile/deploy.yml
@@ -345,9 +345,6 @@ services:
       # Defaults to 100.000. When set to 0, it disables the limit.
       # OR_DATA_POINTS_QUERY_LIMIT: 100000
 
-      # Configure the limit of data points that can be exported to CSV. Defaults to 1 million data points.
-      # OR_DATA_POINTS_EXPORT_LIMIT: 10000000
-
       # App id for the API of OpenWeather: https://openweathermap.org
       # OR_OPEN_WEATHER_API_APP_ID
 

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
@@ -68,17 +68,14 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         )
 
         then: "the default CSV export should return a file"
-        def csvExport1Future = assetDatapointService.exportDatapoints(
+        def inputStream1 = assetDatapointService.exportDatapoints(
                 [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
                 dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
         )
-        assert csvExport1Future != null
-        def csvExport1 = csvExport1Future.get()
-        assert csvExport1 != null
 
         and: "the CSV export should contain all 5 data points"
-        def csvExport1Lines = csvExport1.readLines()
+        def csvExport1Lines = inputStream1.readLines()
         assert csvExport1Lines.size() == 6
         assert csvExport1Lines[1].endsWith("10.0")
         assert csvExport1Lines[2].endsWith("20.0")
@@ -89,18 +86,15 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         /* ------------------------- */
 
         when: "exporting with format CSV_CROSSTAB"
-        def csvExport2Future = assetDatapointService.exportDatapoints(
+        def inputStream2 = assetDatapointService.exportDatapoints(
                 [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
                 dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 DatapointExportFormat.CSV_CROSSTAB
         )
-        assert csvExport2Future != null
-        def csvExport2 = csvExport2Future.get()
-        assert csvExport2 != null
 
         then: "the crosstab CSV export should contain all 5 data points in columnar format"
-        def csvExport2Lines = csvExport2.readLines()
+        def csvExport2Lines = inputStream2.readLines()
         assert csvExport2Lines.size() == 6 // header + 5 data rows
         assert csvExport2Lines[0].contains("timestamp")
         assert csvExport2Lines[0].contains(assetName + ": " + attributeName)
@@ -108,18 +102,15 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         /* ------------------------- */
 
         when: "exporting with format CSV_CROSSTAB_MINUTE"
-        def csvExport3Future = assetDatapointService.exportDatapoints(
+        def inputStream3 = assetDatapointService.exportDatapoints(
                 [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
                 dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 DatapointExportFormat.CSV_CROSSTAB_MINUTE
         )
-        assert csvExport3Future != null
-        def csvExport3 = csvExport3Future.get()
-        assert csvExport3 != null
 
         then: "the time-bucketed CSV export should contain aggregated data with correct values"
-        def csvExport3Lines = csvExport3.readLines()
+        def csvExport3Lines = inputStream3.readLines()
         assert csvExport3Lines.size() >= 2 // header + at least 1 aggregated row
         assert csvExport3Lines[0].contains("timestamp")
         assert csvExport3Lines[0].contains(assetName + ": " + attributeName)
@@ -149,7 +140,7 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         assetDatapointService.datapointExportLimit = 4
 
         and: "we try to export the same amount of data points"
-        def csvExport4Future = assetDatapointService.exportDatapoints(
+        def inputStream4 = assetDatapointService.exportDatapoints(
                 [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
                 dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                 dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
@@ -30,7 +30,6 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
         def assetStorageService = container.getService(AssetStorageService.class)
         def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.datapointExportLimit = 1000
 
         when: "requesting the first light asset in City realm"
         def asset = assetStorageService.find(
@@ -133,25 +132,5 @@ class AssetDatapointExportTest extends Specification implements ManagerContainer
         assert values.contains("30.000") || values.contains("30")
         assert values.contains("40.000") || values.contains("40")
         assert values.contains("50.000") || values.contains("50")
-
-        /* ------------------------- */
-
-        when: "the limit of data export is lowered to 4"
-        assetDatapointService.datapointExportLimit = 4
-
-        and: "we try to export the same amount of data points"
-        def inputStream4 = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        )
-
-        then: "the CSV export should throw an exception"
-        thrown(DatapointQueryTooLargeException)
-
-        /* ------------------------- */
-
-        cleanup: "Remove the limit on datapoint querying"
-        assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT;
     }
 }


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Changes the datapoint exports to write to `stdout` rather than the filesystem and uses piped streams so data can be streamed to the client without having to hold all datapoints in memory.

I did some tests to ensure the memory footprint stays reasonable. With 10 million datapoints exported multiple times in parallel (4 active streams) the memory usage spikes from ~150MB to ~350MB. The zip files that are downloaded each are ~131MB and the `datapoints.csv` files are ~620MB.

[Exporting 10 million datapoints multiple times in parallel](https://github.com/user-attachments/assets/ed61a058-35ce-42e4-9de2-0b0817e2b437)

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
